### PR TITLE
メニュー管理および初期画面管理でWebサイトの一部選択機能の切取り箇所選択の読込み中にオーバーレイを表示するようにする修正

### DIFF
--- a/src/main/web/admin/js/Admin.js
+++ b/src/main/web/admin/js/Admin.js
@@ -354,10 +354,10 @@ ISA_Admin.initIndicator = function() {
 	LoadingDiv.id = "divOverlay";
 	LoadingDiv.className = "nowLoading";
 	indicatorDiv.appendChild(LoadingDiv);
-	
+
 	LoadingDiv.style.top = (findPosY(document.body) + 200) + "px";
 	LoadingDiv.style.left = (findPosX(document.body) + document.body.offsetWidth/2 - divOverlay.offsetWidth/2) + "px";
-
+	LoadingDiv.style.position = 'fixed'
 }
 
 ISA_Admin.startIndicator = function() {
@@ -365,8 +365,8 @@ ISA_Admin.startIndicator = function() {
 		ISA_Admin.initIndicator();
 	var overlay = ISA_Admin.overlay;
 	
-	overlay.style.width = Math.max(document.body.scrollWidth, document.body.clientWidth) + "px";
-	overlay.style.height = Math.max(document.body.scrollHeight, document.body.clientHeight) + "px";
+	overlay.style.width = Math.max(document.documentElement.scrollWidth, document.documentElement.clientWidth) + "px";
+	overlay.style.height = Math.max(document.documentElement.scrollHeight, document.documentElement.clientHeight) + "px";
 	ISA_Admin.indicatorDiv.style.display = "";
 }
 

--- a/src/main/web/admin/js/AdminDefaultPanel.js
+++ b/src/main/web/admin/js/AdminDefaultPanel.js
@@ -780,15 +780,6 @@ ISA_DefaultPanel.prototype.classDef = function() {
 		editImg.title = ISA_R.alb_editing;
 		editTd.appendChild(editImg);
 		
-		// for debug
-		/*
-		var editImg2 = document.createElement("img");
-		editImg2.src = imageURL + "edit.gif";
-		editImg2.style.cursor = "pointer";
-		editImg2.title = ISA_R.alb_editing;
-		editTd.appendChild(editImg2);
-		IS_Event.observe(editImg2, "click", this.editRole.bind(this, jsonRole, roleDiv), false, ["_adminPanelTab","_adminPanel"]);
-		*/
 		if(self.displayTabId == commandBarTabId){
 			IS_Event.observe(editImg, "click", this.editRole.bind(this, jsonRole, roleDiv), false, ["_adminPanelTab","_adminPanel"]);
 		}else{
@@ -2644,6 +2635,12 @@ ISA_DefaultPanel.prototype.classDef = function() {
 			}
 		};
 		AjaxRequest.invoke(url, opt);
+
+		ISA_Admin.initEditRoleIndicator = null;
+		ISA_Admin.startEditRoleIndicator = null;
+		ISA_Admin.stopEditRoleIndicator = null;
+		ISA_Admin.editRoleIndicatorDiv = null;
+		ISA_Admin.editRoleOverlay = null;
 
 		this.isUpdated = false;
 		return true;

--- a/src/main/web/admin/js/AdminEditRole.js
+++ b/src/main/web/admin/js/AdminEditRole.js
@@ -1028,3 +1028,41 @@ function updatePanel(){
 	openerPanel.updatePanel(true);
 }
 Event.observe(window, 'beforeunload', updatePanel);
+
+ISA_Admin.initEditRoleIndicator = function() {
+	var indicatorDiv = document.createElement("div");
+	document.body.appendChild(indicatorDiv);
+	ISA_Admin.editRoleIndicatorDiv = indicatorDiv;
+	
+	var overlay = document.createElement("div");
+	overlay.className = "indicatorOverlay";
+	overlay.id = "drag-overlay";
+	indicatorDiv.appendChild(overlay);
+	ISA_Admin.editRoleOverlay = overlay;
+	
+	LoadingDiv = document.createElement("div");
+	LoadingDiv.id = "divOverlay";
+	LoadingDiv.className = "nowLoading";
+	indicatorDiv.appendChild(LoadingDiv);
+
+	LoadingDiv.style.top = (findPosY(document.body) + 200) + "px";
+	LoadingDiv.style.left = (findPosX(document.body) + document.body.offsetWidth/2 - divOverlay.offsetWidth/2) + "px";
+	LoadingDiv.style.position = 'fixed'
+}
+
+ISA_Admin.startEditRoleIndicator = function() {
+	if(!ISA_Admin.editRoleIndicatorDiv)
+		ISA_Admin.initEditRoleIndicator();
+	var overlay = ISA_Admin.editRoleOverlay;
+	
+	overlay.style.width = '100%';
+	overlay.style.height = Math.max(document.documentElement.scrollHeight, document.documentElement.clientHeight) + "px";
+	ISA_Admin.editRoleIndicatorDiv.style.display = "";
+}
+
+ISA_Admin.stopEditRoleIndicator = function() {
+	if(!ISA_Admin.editRoleIndicatorDiv)
+		ISA_Admin.initEditRoleIndicator();
+	var indicatorDiv = ISA_Admin.editRoleIndicatorDiv;
+	indicatorDiv.style.display = "none";
+}

--- a/src/main/web/admin/js/AdminHTMLFragment.js
+++ b/src/main/web/admin/js/AdminHTMLFragment.js
@@ -6,6 +6,9 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 
 	var currentTargetElement;
 	ISA_Admin.startIndicator();
+
+	if(ISA_Admin.startEditRoleIndicator)
+		ISA_Admin.startEditRoleIndicator();
 	
 	// Display for modal
 	var fragmentDiv = document.createElement("div");
@@ -67,8 +70,18 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 	
 	function loadIframe(authParameters){
 		var _selectXPathPanel = $("selectXPathPanel");
-		if (_selectXPathPanel.style.display == "none")
+		if (_selectXPathPanel.style.display == "none"){
 			_selectXPathPanel.style.display = "";
+
+			// expand overlay height
+			var overlay = ISA_Admin.overlay;
+			var editRoleOverlay = ISA_Admin.editRoleOverlay;
+			if(!editRoleOverlay){
+				overlay.style.height = Math.max(document.documentElement.scrollHeight, document.documentElement.clientHeight) + "px";				
+			}else{
+				editRoleOverlay.style.height = Math.max(document.documentElement.scrollHeight, document.documentElement.clientHeight) + "px";			
+			}
+		}
 		
 		if (_selectXPathPanel.firstChild) {
 			_selectXPathPanel.replaceChild(fragmentDiv, _selectXPathPanel.firstChild);
@@ -113,7 +126,10 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 	
 	function cancelXPathSelection() {
 		ISA_Admin.stopIndicator();
-		
+
+		if(ISA_Admin.stopEditRoleIndicator)
+			ISA_Admin.stopEditRoleIndicator();
+
 		var selectXPathPanel = $("selectXPathPanel");
 		if(!selectXPathPanel) return;
 		selectXPathPanel.style.display = "none";
@@ -122,6 +138,8 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 		var _authType = response.getResponseHeader("MSDPortal-AuthType");
 		if(_authType){
 			ISA_Admin.stopIndicator();
+			if(ISA_Admin.stopEditRoleIndicator)
+				ISA_Admin.stopEditRoleIndicator();
 			showAuthForm(_authType);
 		}else{
 			loadIframe();
@@ -139,6 +157,8 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 			  alert(msgbody);
 			  msg.error(msgbody);
 			  ISA_Admin.stopIndicator();
+		  	  if(ISA_Admin.stopEditRoleIndicator)
+				ISA_Admin.stopEditRoleIndicator();
 			  fragmentDiv = false;
 		  },
 		  on10408: function(r,t) {
@@ -146,6 +166,8 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 			  alert(msgbody);
 			  msg.error(msgbody);
 			  ISA_Admin.stopIndicator();
+		  	  if(ISA_Admin.stopEditRoleIndicator)
+				ISA_Admin.stopEditRoleIndicator();
 			  fragmentDiv = false;
 		  },
 		  onFailure: function(t) {
@@ -153,6 +175,8 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 			  alert(msgbody);
 			  msg.error(msgbody);
 			  ISA_Admin.stopIndicator();
+		  	  if(ISA_Admin.stopEditRoleIndicator)
+				ISA_Admin.stopEditRoleIndicator();			  
 			  fragmentDiv = false;
 		  },
 		  onException: function(r, t){
@@ -160,6 +184,8 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 			  alert(msgbody);
 			  msg.error(msgbody);
 			  ISA_Admin.stopIndicator();
+		  	  if(ISA_Admin.stopEditRoleIndicator)
+				ISA_Admin.stopEditRoleIndicator();
 			  fragmentDiv = false;
 		  }
 		};
@@ -250,6 +276,8 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 		}
 		$("currentXPathForm").value = "";
 		ISA_Admin.stopIndicator();
+	  	if(ISA_Admin.stopEditRoleIndicator)
+			ISA_Admin.stopEditRoleIndicator();
 	}
 	
 	function makeXPath(elm){
@@ -291,15 +319,6 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 	}
 	
 	function addFragmentWidgetInstance() {
-		/*
-		var thumbnail = "";
-		var thumbnailDiv = $("addInstThumbnail_FragmentMiniBrowser");
-		if(thumbnailDiv && 0 < thumbnailDiv.value.length){
-			var trimValue = thumbnailDiv.value.replace(/ |　/, "");
-			if(0 < trimValue.length)
-			  thumbnail = thumbnailDiv.value;
-		}
-		*/
 		var fragmentXPath = $("currentXPathForm").value;
 		var xpath = (fragmentXPath)? fragmentXPath : '//body';
 		

--- a/src/main/web/skin/admin.css
+++ b/src/main/web/skin/admin.css
@@ -873,7 +873,7 @@ a.gadgetListTabA:visited{
 	width : 128px;
 	height : 128px;
 	position : absolute;
-	z-index: 10000;
+	z-index: 100000;
 }
 
 #portalLayouts{


### PR DESCRIPTION
管理画面／メニュー、管理画面／レイアウト／初期画面設定のガジェット設定において切り取りミニブラウザを設定時、指定サイトを読み込む際オーバーレイが正常に表示されない問題がありました。

このオーバーレイを表示するようにし、他のボタンにアクセスできないように修正しました。
