### PR TITLE
メニュー管理および初期画面管理でWebサイトの一部選択機能の切取り箇所選択の読込み中にセレクトボックスが操作できてしまう問題の修正

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -520,6 +520,7 @@
 			<filelist dir="${src.admin.web}/js" files="AdminForbiddenURL.js"/>
 			<filelist dir="${src.admin.web}/js" files="AdminInformation.js"/>
 			<filelist dir="${src.admin.web}/js" files="AdminAuthentication.js"/>
+			<filelist dir="${src.admin.web}/js" files="AdminUtil.js"/>
 		</concat>
 		<java jar="${yuicompressor}" fork="true">
 			<arg line="--type js --charset UTF-8 -o &quot;${build.admin}/js/dist/PortalAdmin-${build.version}.js&quot; &quot;${build.admin}/js/dist/PortalAdmin.js.tmp&quot;"/>
@@ -584,6 +585,7 @@
 			<filelist dir="${src.admin.web}/js" files="AdminHTMLFragment.js"/>
 			<filelist dir="${src.admin.web}/js" files="AdminCommonModals.js"/>
 			<filelist dir="${src.admin.web}/js" files="AdminEditRole.js"/>
+			<filelist dir="${src.admin.web}/js" files="AdminUtil.js"/>
 		</concat>
 		<java jar="${yuicompressor}" fork="true">
 			<arg line="--type js --charset UTF-8 -o &quot;${build.admin}/js/dist/PortalAdmin-EditRole-${build.version}.js&quot; &quot;${build.admin}/js/dist/PortalAdmin-EditRole.js.tmp&quot;"/>

--- a/src/main/web/WEB-INF/jsp/admin/defaultpanel/editRole.jsp
+++ b/src/main/web/WEB-INF/jsp/admin/defaultpanel/editRole.jsp
@@ -198,6 +198,7 @@
 	<script src="../../admin/js/AdminHTMLFragment.js"></script>
 	<script src="../../admin/js/AdminCommonModals.js"></script>
 	<script src="../../admin/js/AdminEditRole.js"></script>
+	<script src="../../admin/js/AdminUtil.js"></script>	
 	<!--end script-->
 	
 	<script src="../../js/lib/jquery-1.9.1.min.js"></script>

--- a/src/main/web/WEB-INF/jsp/admin/tiles/page_head.jsp
+++ b/src/main/web/WEB-INF/jsp/admin/tiles/page_head.jsp
@@ -137,6 +137,7 @@
 		<script src="../../admin/js/AdminGadgetUploadForm.js"></script>
 		<script src="../../admin/js/AdminInformation.js"></script>
 		<script src="../../admin/js/AdminAuthentication.js"></script>
+		<script src="../../admin/js/AdminUtil.js"></script>	
 		<!--end script-->
 		
 		<script src="../../js/lib/jquery-1.9.1.min.js"></script>

--- a/src/main/web/admin/js/Admin.js
+++ b/src/main/web/admin/js/Admin.js
@@ -339,45 +339,6 @@ ISA_Admin.countries = {
 	"US":"US(" + IS_R.lb_countryUS + ")"
 };
 
-ISA_Admin.initIndicator = function() {
-	var indicatorDiv = document.createElement("div");
-	document.body.appendChild(indicatorDiv);
-	ISA_Admin.indicatorDiv = indicatorDiv;
-	
-	var overlay = document.createElement("div");
-	overlay.className = "indicatorOverlay";
-	overlay.id = "drag-overlay";
-	indicatorDiv.appendChild(overlay);
-	ISA_Admin.overlay = overlay;
-	
-	LoadingDiv = document.createElement("div");
-	LoadingDiv.id = "divOverlay";
-	LoadingDiv.className = "nowLoading";
-	indicatorDiv.appendChild(LoadingDiv);
-	
-	LoadingDiv.style.top = (findPosY(document.body) + 200) + "px";
-	LoadingDiv.style.left = (findPosX(document.body) + document.body.offsetWidth/2 - divOverlay.offsetWidth/2) + "px";
-
-}
-
-ISA_Admin.startIndicator = function() {
-	if(!ISA_Admin.indicatorDiv)
-		ISA_Admin.initIndicator();
-	var overlay = ISA_Admin.overlay;
-	
-	overlay.style.width = Math.max(document.body.scrollWidth, document.body.clientWidth) + "px";
-	overlay.style.height = Math.max(document.body.scrollHeight, document.body.clientHeight) + "px";
-	ISA_Admin.indicatorDiv.style.display = "";
-}
-
-ISA_Admin.stopIndicator = function() {
-	if(!ISA_Admin.indicatorDiv)
-		ISA_Admin.initIndicator();
-	var indicatorDiv = ISA_Admin.indicatorDiv;
-	indicatorDiv.style.display = "none";
-}
-
-
 /**
  * Create common table header of administration page
  */

--- a/src/main/web/admin/js/AdminEditWidgetConf.js
+++ b/src/main/web/admin/js/AdminEditWidgetConf.js
@@ -248,7 +248,7 @@ ISA_WidgetConf.makeForm = function(prefType, prefConf, widgetType, prefValue, is
 		textarea.id = prefType + '_' + prefConf.name;
 		textarea.rows = "12";
 		textarea.wrap = "off";
-		textarea.style.width = "100%";
+		textarea.style.width = "99%";
 		//Content may be inserted if prefConf is WidgetPref...
 		textarea.value = prefValue || "";
 		IS_Event.observe(textarea, 'change', onChange.bind(textarea, prefConf), false, "_widgetEditForm");

--- a/src/main/web/admin/js/AdminHTMLFragment.js
+++ b/src/main/web/admin/js/AdminHTMLFragment.js
@@ -48,7 +48,8 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 	
 	var xpath = document.createElement("input");
 	xpath.id = "currentXPathForm";
-	xpath.style.width = "100%";
+	xpath.type = "text";
+	xpath.style.width = "99%";
 	xpath.style.border = "1px solid #000000";
 	xpath.style.backgroundColor = "#EEEEEE";
 	xpath.readonly = true;
@@ -67,8 +68,7 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 	
 	function loadIframe(authParameters){
 		var _selectXPathPanel = $("selectXPathPanel");
-		if (_selectXPathPanel.style.display == "none")
-			_selectXPathPanel.style.display = "";
+		_selectXPathPanel.show();
 		
 		if (_selectXPathPanel.firstChild) {
 			_selectXPathPanel.replaceChild(fragmentDiv, _selectXPathPanel.firstChild);
@@ -78,6 +78,7 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 					
 		iframe.src = getProxyUrl(inputURL, "URLReplace", filterEncoding) + ((authParameters) ? authParameters : "");
 		iframe.setAttribute("frameborder", "0");
+		iframe.style.width = '99%';
 	
 		IS_Event.observe(iframe, 'load', setEvent.bind(this, iframe), false, "addWidgetEdit");
 	}
@@ -116,7 +117,7 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 		
 		var selectXPathPanel = $("selectXPathPanel");
 		if(!selectXPathPanel) return;
-		selectXPathPanel.style.display = "none";
+		selectXPathPanel.hide();
 	}
 	function setIframeURL(response){
 		var _authType = response.getResponseHeader("MSDPortal-AuthType");
@@ -291,15 +292,6 @@ ISA_WidgetConf.EditWidgetConf.displayFragmentModal = function( prefType, inputUR
 	}
 	
 	function addFragmentWidgetInstance() {
-		/*
-		var thumbnail = "";
-		var thumbnailDiv = $("addInstThumbnail_FragmentMiniBrowser");
-		if(thumbnailDiv && 0 < thumbnailDiv.value.length){
-			var trimValue = thumbnailDiv.value.replace(/ |　/, "");
-			if(0 < trimValue.length)
-			  thumbnail = thumbnailDiv.value;
-		}
-		*/
 		var fragmentXPath = $("currentXPathForm").value;
 		var xpath = (fragmentXPath)? fragmentXPath : '//body';
 		

--- a/src/main/web/admin/js/AdminUtil.js
+++ b/src/main/web/admin/js/AdminUtil.js
@@ -1,0 +1,31 @@
+ISA_Admin.initIndicator = function() {
+	var indicatorDiv = document.createElement("div");
+	indicatorDiv.id = "indicatorDiv"
+	document.body.appendChild(indicatorDiv);
+	ISA_Admin.indicatorDiv = indicatorDiv;
+	
+	var overlay = document.createElement("div");
+	overlay.className = "indicatorOverlay";
+	overlay.id = "drag-overlay";
+	indicatorDiv.appendChild(overlay);
+	ISA_Admin.overlay = overlay;
+	
+	LoadingDiv = document.createElement("div");
+	LoadingDiv.id = "divOverlay";
+	LoadingDiv.className = "nowLoading";
+	indicatorDiv.appendChild(LoadingDiv);
+}
+
+ISA_Admin.startIndicator = function() {
+	var indicatorDiv = document.getElementById('indicatorDiv');
+	if(!indicatorDiv)
+		ISA_Admin.initIndicator();
+	ISA_Admin.indicatorDiv.show();
+}
+
+ISA_Admin.stopIndicator = function() {
+	if(!ISA_Admin.indicatorDiv)
+		ISA_Admin.initIndicator();
+	var indicatorDiv = ISA_Admin.indicatorDiv;
+	indicatorDiv.hide();
+}

--- a/src/main/web/skin/admin.css
+++ b/src/main/web/skin/admin.css
@@ -859,9 +859,11 @@ a.gadgetListTabA:visited{
 }
 
 .indicatorOverlay {
-	position:absolute;
+	position:fixed;
 	left:0px;
 	top:0px;
+	width:100%;
+	height:100%;
 	z-index:90000;
 	-moz-opacity:0.4;
 	opacity:0.4;
@@ -870,10 +872,14 @@ a.gadgetListTabA:visited{
 }
 .nowLoading {
 	background : url(./imgs/indicator_verybig.gif) top center no-repeat;
+	top: 50%;
+	left: 50%;
+	margin-top: -64px;
+	margin-left: -64px;
 	width : 128px;
 	height : 128px;
-	position : absolute;
-	z-index: 10000;
+	position : fixed;
+	z-index: 100000;
 }
 
 #portalLayouts{


### PR DESCRIPTION
オーバーレイを管理する関数を別ファイルに切り出し、そこを呼び出すように変更しました。

引数としてオブジェクトを渡す方法も試してみましたが、IEでうまく渡すことができなかったためこのような仕組みにしてあります。

Admin.jsにはUtilとして切り出せる関数がいくつかあると思いますので、作成したJSはAdminUtil.jsとしています。

IE8、IE9、FFESR17にて動作確認はしてあります。
