### PR TITLE
プロビジョニングAPIのパフォーマンス改善

### DIFF
--- a/src/api/java/org/infoscoop/api/rest/v1/controller/admin/ProvisioningController.java
+++ b/src/api/java/org/infoscoop/api/rest/v1/controller/admin/ProvisioningController.java
@@ -71,7 +71,7 @@ public class ProvisioningController extends BaseController{
 					+ ";charset=utf-8")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody()
-	public ProvisioningList getAccountsBySquareId(@PathVariable("squareId") String squareId) throws Exception {
+	public ProvisioningList getAccountsBySquareId(@PathVariable("squareId") String squareId, @RequestParam(required = false) boolean withAllParams) throws Exception {
 		String execSquareId = getSquareId();
 		ProvisioningList provisioningList = new ProvisioningList();
 		List<Provisioning> list = new ArrayList<>();
@@ -96,8 +96,13 @@ public class ProvisioningController extends BaseController{
 			}
 
 			provisioning.name = account.getName();
-			provisioning.belongSquare = service.getBelongSquare(account, execSquareId);
-			provisioning.attrs = service.getAccountAttribute(account, execSquareId);
+			
+			// 属性、所属スクエアはデフォルトでは取得しない
+			if(withAllParams){
+				// TODO: パフォーマンス改善
+				provisioning.belongSquare = service.getBelongSquare(account, execSquareId);
+				provisioning.attrs = service.getAccountAttribute(account, execSquareId);
+			}
 			list.add(provisioning);
 		}
 

--- a/src/api/java/org/infoscoop/api/rest/v1/service/admin/ProvisioningService.java
+++ b/src/api/java/org/infoscoop/api/rest/v1/service/admin/ProvisioningService.java
@@ -59,7 +59,7 @@ public class ProvisioningService {
 				Pat.2: sent squareid == getSquareId.childSquareId (OK)
 			*/
 			if(!defaultSquareId.equals(execSquareId)
-					&& (!SquareService.getHandle().isNotDefaultUntilAncient(defaultSquareId, execSquareId) || !SquareService.getHandle().comparisonParentSquare(defaultSquareId, execSquareId)))
+					&& (!SquareService.getHandle().isNotDefaultUntilAncient(defaultSquareId) || !SquareService.getHandle().comparisonParentSquare(defaultSquareId, execSquareId)))
 				throw new IllegalArgumentException("users[" + index + "].default_square_id is not owned square.");
 		}
 
@@ -86,7 +86,7 @@ public class ProvisioningService {
 					Pat.2: sent squareid == getSquareId.childSquareId (OK)
 				*/
 				if(!squareId.equals(execSquareId)
-						&& (!SquareService.getHandle().isNotDefaultUntilAncient(squareId, execSquareId) || !SquareService.getHandle().comparisonParentSquare(squareId, execSquareId)))
+						&& (!SquareService.getHandle().isNotDefaultUntilAncient(squareId) || !SquareService.getHandle().comparisonParentSquare(squareId, execSquareId)))
 					throw new IllegalArgumentException("users[" + index + "].belong_square[" + i +"].id[" + squareId + "] is not owned square.");
 			}
 		}
@@ -126,7 +126,7 @@ public class ProvisioningService {
 					Pat.2: sent squareid == getSquareId.childSquareId (OK)
 				 */
 					if(!squareId.equals(execSquareId)
-							&& (!SquareService.getHandle().isNotDefaultUntilAncient(squareId, execSquareId) || !SquareService.getHandle().comparisonParentSquare(squareId, execSquareId)))
+							&& (!SquareService.getHandle().isNotDefaultUntilAncient(squareId) || !SquareService.getHandle().comparisonParentSquare(squareId, execSquareId)))
 						throw new IllegalArgumentException("users[" + index + "].attrs[" + i +"].square_id[" + squareId + "] is not owned square.");
 
 					// belong
@@ -270,7 +270,7 @@ public class ProvisioningService {
 					map.put(AccountAttr.PROP_NAME, accountAttr.get(AccountAttr.PROP_NAME));
 					map.put(AccountAttr.PROP_VALUE, accountAttr.get(AccountAttr.PROP_VALUE));
 				} else if(squareId.equals(execSquareId)
-						|| (SquareService.getHandle().isNotDefaultUntilAncient(squareId, execSquareId) && SquareService.getHandle().comparisonParentSquare(squareId, execSquareId))) {
+						|| (SquareService.getHandle().isNotDefaultUntilAncient(squareId) && SquareService.getHandle().comparisonParentSquare(squareId, execSquareId))) {
 					map.put(AccountAttr.PROP_NAME, accountAttr.get(AccountAttr.PROP_NAME));
 					map.put(AccountAttr.PROP_VALUE, accountAttr.get(AccountAttr.PROP_VALUE));
 					map.put(AccountAttr.PROP_SQUARE_ID, squareId);
@@ -288,8 +288,11 @@ public class ProvisioningService {
 
 		for(String belongId : belongIds) {
 			Map<String, String> map = new HashMap<>();
+
+			String parentSquareId = SquareService.getHandle().getParentSquareId(belongId);
+			
 			if(belongId.equals(execSquareId)
-					|| (SquareService.getHandle().isNotDefaultUntilAncient(belongId, execSquareId) && SquareService.getHandle().comparisonParentSquare(belongId, execSquareId))) {
+					|| (SquareService.getHandle().isNotDefaultUntilAncient(belongId, parentSquareId) && SquareService.getHandle().comparisonParentSquare(belongId, execSquareId, parentSquareId))) {
 				map.put("id", belongId);
 				resultList.add(map);
 			}

--- a/src/main/java/org/infoscoop/dao/AccountDAO.java
+++ b/src/main/java/org/infoscoop/dao/AccountDAO.java
@@ -20,6 +20,7 @@ package org.infoscoop.dao;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.Criteria;
 import org.hibernate.criterion.CriteriaSpecification;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Expression;
@@ -255,7 +256,9 @@ public class AccountDAO extends HibernateDaoSupport {
 		String squareId = (String)condition.get("user_belong_square");
 
 		DetachedCriteria criteria = DetachedCriteria.forClass(Account.class).createAlias("AccountSquares", "as", CriteriaSpecification.LEFT_JOIN);
-
+		criteria.createAlias("AccountAttrs", "attrs", CriteriaSpecification.LEFT_JOIN);
+		criteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
+		
 		if(uid != null)
 			criteria.add(Expression.eq("Uid", uid));
 		

--- a/src/main/java/org/infoscoop/service/SquareService.java
+++ b/src/main/java/org/infoscoop/service/SquareService.java
@@ -356,9 +356,11 @@ public class SquareService {
 		return parentSquareId;
 	}
 
-	public boolean comparisonParentSquare(String child, String parent) {
+	public boolean comparisonParentSquare(String child, String parent, String parentSquareId) {
 		boolean result = true;
-		String parentSquareId = this.getParentSquareId(child);
+		
+		if(parentSquareId == null)
+			parentSquareId = this.getParentSquareId(child);
 
 		// do not null
 		if(parentSquareId != null && parentSquareId.length() > 0)
@@ -367,9 +369,15 @@ public class SquareService {
 		return result;
 	}
 
-	public boolean isNotDefaultUntilAncient(String child, String parent) {
+	public boolean comparisonParentSquare(String child, String parent) {
+		return comparisonParentSquare(child, parent, null);
+	}
+	public boolean isNotDefaultUntilAncient(String child, String parentSquareId) {
 		boolean result = true;
-		String parentSquareId = this.getParentSquareId(child);
+		
+		if(parentSquareId == null)
+			parentSquareId = this.getParentSquareId(child);
+		
 		if(parentSquareId == null) return false;
 
 		if(child.equals(SQUARE_ID_DEFAULT) || "".equals(parentSquareId) || SQUARE_ID_DEFAULT.equals(parentSquareId))
@@ -378,6 +386,10 @@ public class SquareService {
 		return result;
 	}
 
+	public boolean isNotDefaultUntilAncient(String child) {
+		return isNotDefaultUntilAncient(child , null);
+	}
+	
 	public void updateSquare(String squareId, String name, String description){
 		Square square = squareDAO.get(squareId);
 		square.setName(name);


### PR DESCRIPTION
・ACCOUNTS用の汎用検索クエリがlazy fetch的動作になっていたため修正
・デフォルトでは属性や所属情報をレスポンスに含めないように仕様を変更
・パラメータ withAllParams=true 指定時は属性、所属情報を含める（従来の動作）