### PR TITLE
マイスクエア仕様変更に伴うプロビジョニングAPI（ユーザ更新）の修正

### DIFF
--- a/src/api/java/org/infoscoop/api/rest/v1/service/admin/ProvisioningService.java
+++ b/src/api/java/org/infoscoop/api/rest/v1/service/admin/ProvisioningService.java
@@ -305,13 +305,10 @@ public class ProvisioningService {
 		IAccount account = manager.getUser(uid);
 
 		// repository data
-		String mySquareId = account.getMySquareId();
 		List<String> repoSquareList = account.getBelongids();
 
 		// temp set
 		Set<String> resultSquareIdSet = new HashSet<>();
-		// save mysquare
-		resultSquareIdSet.add(mySquareId);
 
 		// result set
 		for(Map<String, String> squareMap : belongSquareList) {
@@ -320,8 +317,8 @@ public class ProvisioningService {
 			String sendingSquareId = squareMap.get("id");
 			String bgImg = squareMap.get("background_image");
 
-			if(sendingSquareId.equals(mySquareId)
-					|| (!sendingSquareId.equals(execSquareId) && !SquareService.getHandle().comparisonParentSquare(sendingSquareId, execSquareId))) {
+			if(!sendingSquareId.equals(execSquareId)
+					&& !SquareService.getHandle().comparisonParentSquare(sendingSquareId, execSquareId)) {
 				continue;
 			}
 


### PR DESCRIPTION
■原因
マイスクエアに対するPUT(更新）を明示的に抑制しているため、マイスクエアからの追い出し、およびマイスクエアへ再所属させることができない。
サービス利用者は基本的にマイスクエア＝サービススクエアとなるため、スクエア除去や再所属などの更新操作ができない状態となっていた。
マイスクエアは廃止されたが、プロビジョニングAPIにはその制御が残っている感じ。

■対処方針
マイスクエアの状態が保持されるようにハンドリングされているので、それを外す。